### PR TITLE
feat: enhance discount application logic with reapply parameter

### DIFF
--- a/static/js/cart.js
+++ b/static/js/cart.js
@@ -240,7 +240,14 @@ function updateCartSummary() {
     const shippingCost     = parseFloat(shippingAndHandling.textContent.slice(1)); 
 
     priceTotal.textContent = concatenateWithDelimiter(sign, total);
-    orderTotal.textContent = concatenateWithDelimiter(sign, (total + tax + shippingCost));
+
+    const totalOrderCost   = (total + tax + shippingCost);
+    orderTotal.textContent = concatenateWithDelimiter(sign, totalOrderCost);
+
+    if (discountManager.isDiscountApplied()) {
+        const discountCode = discountManager.getCurrentAppliedDiscountCode();
+        discountManager.applyDiscount(discountCode, true);
+    };
 
     const elements = [priceTotal, orderTotal];
 

--- a/static/js/handle-discount-form.js
+++ b/static/js/handle-discount-form.js
@@ -33,7 +33,7 @@ export function applyDashToInput(e) {
         const fieldValue = santizeValue[i];
     
         if (i > 0 && i % 5 === 0 ) {
-            text += `-${fieldValue}`;
+            text += concatenateWithDelimiter("-", fieldValue);
         } else {
             text += fieldValue
         }
@@ -54,14 +54,16 @@ export const discountManager = {
     },
     _discountApplied: false,
     _currency: null,
+    _currentDiscountCode: null,
 
     /**
      * Applies a discount to the cart total if the provided code is valid and has not already been applied.
      * 
      * @param {string} code - The discount code entered by the user.
+     * @param {boolean} allowReapply - If true, allows reapplying the discount even if it's already applied.
      * @returns {boolean} - Returns `true` if the discount is successfully applied, otherwise `false`.
      */
-    applyDiscount: (code) => {
+    applyDiscount: (code, allowReapply = false) => {
 
         if (!code) return;
 
@@ -70,7 +72,7 @@ export const discountManager = {
         if (discountPercentage !== undefined) {
             showSpinnerFor(spinner);
 
-            if (discountManager._isDiscountApplied()) {
+            if (discountManager.isDiscountApplied() && !allowReapply) {
                 const msg = "This discount has already been applied.";
                 showPopupMessage(msg);
                 return false;
@@ -78,17 +80,13 @@ export const discountManager = {
 
             discountManager._discountApplied = true;
 
-            const cartTotal = discountManager._getCartTotal();
+            const cartTotal      = discountManager._getCartTotal();
             const discountAmount = (discountPercentage / 100) * cartTotal;
-            const newTotal = cartTotal - discountAmount;
+            const newTotal       = cartTotal - discountAmount;
 
             discountManager._renderNewTotal(newTotal, discountPercentage);
             return true;
         }
-
-        const msg = "The discount code you entered is invalid.";
-        showPopupMessage(msg);
-        return false;
     },
 
     /**
@@ -102,7 +100,23 @@ export const discountManager = {
 
         // Normalise the code to uppercase to handle case-insensitive matches
         const normalisedCode = code.toUpperCase();
-        return discountManager._discounts[normalisedCode];
+
+        const discountCode = discountManager._discounts[normalisedCode];
+
+        if (discountCode) {
+            discountManager._currentDiscountCode = normalisedCode;
+        }
+        return discountCode;
+
+    },
+
+    /**
+    * Retrieves the discount code currently applied.
+    * @returns {string|null} The applied discount code, or null if no discount is applied.
+    */
+     getCurrentAppliedDiscountCode: () => {
+        return discountManager._currentDiscountCode;
+
     },
 
     /**
@@ -110,7 +124,7 @@ export const discountManager = {
      * 
      * @returns {boolean} - Returns `true` if the discount is already applied, otherwise `false`.
      */
-    _isDiscountApplied: () => {
+    isDiscountApplied: () => {
         return discountManager._discountApplied;
     },
 


### PR DESCRIPTION
Updated `discountMangager` to recalculate the discount when the product updates or decrease as long as a discount has been applied

- Added the `allowReapply` parameter to the `applyDiscount`
  method to handle scenarios where the cart is updated ensuring discounts can be recalculated when necessary. Now when the
- Improved user experience by allowing discounts to be reapplied seamlessly after cart changes.
- Added checks to prevent duplicate discount application unless explicitly allowed.

Workflow
- A user can add a discount code to their cart, update their cart and the discount is re-applied to their cart total.