### PR TITLE
Feat: Add removeCounterIfNoProductsReserved function

### DIFF
--- a/static/js/cart.js
+++ b/static/js/cart.js
@@ -345,6 +345,7 @@ function removeFromCart(e, silent=false) {
             updateCartQuantityTag(priceElementsArray);
             toggleSpinner(spinner, false);
             removeCardSummary();
+            removeTimerifNoProductsReserved();
          
 
         }, TIME_IN_MILLSECONDS);
@@ -358,6 +359,12 @@ function removeFromCart(e, silent=false) {
    
 };
 
+
+function removeTimerifNoProductsReserved() {
+    if (priceElementsArray.length === 0) {
+        checkoutTimer.remove();
+    }
+}
 
 
 function reserveProductTimer() {


### PR DESCRIPTION
Implemented `removeCounterIfNoProductsReserved` to dynamically remove the reserved product timer when no products are reserved. This means that the reserve timer is only displayed when they are items in the cart, and if the user should remove physically then the timer is also removed.